### PR TITLE
Fix hatchling configuration for src/ layout CLI installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ env-embeddings = "env_embeddings.cli:main"
 # explicitly include files other than default into the build distributions.
 
 [tool.hatch.build.targets.wheel]
+packages = ["src/env_embeddings"]
 include = [
   "src/env_embeddings/py.typed",
 ]


### PR DESCRIPTION
Add packages configuration to pyproject.toml to resolve ModuleNotFoundError when running CLI after uv sync. This ensures proper editable installation of the env_embeddings package from the src/ directory structure.

Fixes #19

🤖 Generated with [Claude Code](https://claude.ai/code)