### PR TITLE
Fix hatchling configuration for CLI installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ env-embeddings = "env_embeddings.cli:main"
 # explicitly include files other than default into the build distributions.
 
 [tool.hatch.build.targets.wheel]
+packages = ["src/env_embeddings"]
 include = [
   "src/env_embeddings/py.typed",
 ]


### PR DESCRIPTION
Add packages = ["src/env_embeddings"] to pyproject.toml to resolve the ModuleNotFoundError when running CLI commands after uv sync.

This ensures proper editable installation of the env_embeddings package from the src/ directory structure by telling hatchling where to find the source code.

Before: CLI fails with "ModuleNotFoundError: No module named 'env_embeddings'"
After: CLI works correctly with all commands

Fixes #19

Testing:
- uv sync --reinstall-package env-embeddings
- uv run env-embeddings --help ✅
- uv run env-embeddings init-ee --project test ✅

🤖 Generated with [Claude Code](https://claude.ai/code)