### PR TITLE
Exclude notebooks directory from ruff linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,14 @@ vcs = "git"
 style = "pep440"
 fallback-version = "0.0.0"
 
+# Ruff configuration - exclude notebooks directory from linting
+[tool.ruff]
+exclude = [
+    "notebooks/",
+    ".venv/",
+    "__pycache__/",
+]
+
 # Ref.: https://docs.pytest.org/en/stable/reference/reference.html#configuration-options
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Configures ruff to exclude the notebooks/ directory from linting checks in GitHub Actions CI.

## Problem
Jupyter notebooks contain different code patterns (cells, interactive execution, exploratory analysis) that don't follow the same strict linting rules as production Python code. This was causing CI failures on the recently added similarity analysis notebook.

## Solution
Added [tool.ruff] configuration section to pyproject.toml with exclusions for:
- notebooks/ - Analysis and exploration notebooks
- .venv/ - Virtual environment files  
- __pycache__/ - Python cache directories

## Testing
✅ Verified 'uv run ruff check .' now passes without notebook linting errors
✅ Notebooks are properly excluded from the 'just format' command used in CI
✅ Regular source code linting still works normally

## Impact
- CI builds will now pass despite having Jupyter notebooks
- Notebooks can use exploratory/analysis patterns without strict linting
- Production source code still maintains full linting coverage

This allows the analysis notebooks to coexist with the production codebase without compromising code quality standards.