### PR TITLE
Fix Claude Code action model name

### DIFF
--- a/.github/actions/claude-code-action/action.yml
+++ b/.github/actions/claude-code-action/action.yml
@@ -139,6 +139,7 @@ runs:
             -p \
             --verbose \
             --output-format stream-json \
+            --model anthropic/claude-sonnet \
             "$(cat ${{ env.PROMPT_PATH }})" \
             ${{ inputs.allowed_tools != '' && format('--allowedTools "{0}"', inputs.allowed_tools) || '' }}
         else
@@ -147,6 +148,7 @@ runs:
             -p \
             --verbose \
             --output-format stream-json \
+            --model anthropic/claude-sonnet \
             "$(cat ${{ env.PROMPT_PATH }})" \
             ${{ inputs.allowed_tools != '' && format('--allowedTools "{0}"', inputs.allowed_tools) || '' }} | tee output.txt
 


### PR DESCRIPTION
## Summary
- Fixed invalid model name error in Claude Code GitHub action
- Added `--model anthropic/claude-sonnet` flag to Claude invocations

## Problem
The action was failing with:
```
API Error: 400 Invalid model name passed in model=claude-sonnet-4-5-20250929
```

## Solution
Explicitly specify the correct model name compatible with the CBORG API endpoint.

🤖 Generated with [Claude Code](https://claude.ai/code)